### PR TITLE
Replace es5 functions by es6 to bind this and fix ios bugs

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -2,7 +2,7 @@
 	"nativescript": {
 		"id": "org.nativescript.snackbar",
 		"tns-ios": {
-			"version": "1.5.2"
+			"version": "2.1.1"
 		},
 		"tns-android": {
 			"version": "2.1.1"

--- a/snackbar.android.ts
+++ b/snackbar.android.ts
@@ -11,7 +11,7 @@ export class SnackBar {
     private _snackbar: android.support.design.widget.Snackbar;
     private _snackCallback = android.support.design.widget.Snackbar.Callback.extend({
         resolve: null,
-        onDismissed: function (snackbar, event) {
+        onDismissed (snackbar, event) {
             if (event != 1) {
                 this.resolve({
                     command: "Dismiss",
@@ -92,7 +92,7 @@ export class SnackBar {
                 try {
                     this._snackbar.dismiss();
                     //Return AFTER the item is dismissed, 200ms delay
-                    setTimeout(function () {
+                    setTimeout(() => {
                         resolve({
                             action: "Dismiss",
                             reason: _getReason(3)

--- a/snackbar.d.ts
+++ b/snackbar.d.ts
@@ -1,38 +1,31 @@
 /**
- * Contains the SnackBar class, which represents a checkbox component.
+ * Represents the SnackBar.
  */
-declare module "nativescript-snackbar" {
+export class SnackBar {
 
     /**
-     * Represents the SnackBar.
+    * Shows a simple SnackBar.
+    * @param {string} - The SnackBar text.
+    * @returns {number} Android color int
+    */
+    simple(snackText: string): Promise<any>;
+
+    /**
+     * Show a SnackBar with Action
      */
-    export class SnackBar {
+    action(options: SnackBarOptions): Promise<any>;
 
-        /**
-        * Shows a simple SnackBar.
-        * @param {string} - The SnackBar text.
-        * @returns {number} Android color int
-        */
-        simple(snackText: string): Promise<any>;
+    /**
+     * Manually Dismiss an active SnackBar.
+     */
+    dismiss(): Promise<any>;
 
-        /**
-         * Show a SnackBar with Action
-         */
-        action(options: SnackBarOptions): Promise<any>;
-
-        /**
-         * Manually Dismiss an active SnackBar.
-         */
-        dismiss(): Promise<any>;
-
-    }
+}
 
 
-    export interface SnackBarOptions {
-        actionText: string,
-        actionTextColor: string,
-        snackText: string,
-        hideDelay: number
-    }
-
+export interface SnackBarOptions {
+    actionText: string,
+    actionTextColor: string,
+    snackText: string,
+    hideDelay: number
 }

--- a/snackbar.ios.ts
+++ b/snackbar.ios.ts
@@ -18,7 +18,7 @@ export class SnackBar {
                     snackText,
                     this._getActionText(),
                     timeout,
-                    function (args) {
+                    (args) => {
                         //Action, Do Nothing, just close it
                         this._snackbar.dismiss(); //Force close
                         resolve({
@@ -27,7 +27,7 @@ export class SnackBar {
                             event: args
                         });
                     },
-                    function (args) {
+                    (args) => {
                         //Dismissal, Do Nothing
                         resolve({
                             command: "Dismiss",
@@ -61,13 +61,13 @@ export class SnackBar {
                     options.snackText,
                     options.actionText,
                     options.hideDelay / 1000,
-                    function (args) {
+                    (args) => {
                         resolve({
                             command: "Action",
                             event: args
                         });
                     },
-                    function (args) {
+                    (args) => {
                         let reason = (this._isDismissedManual) ? "Manual" : "Timeout";
                         this._isDismissedManual = false; //reset
                         resolve({
@@ -90,14 +90,14 @@ export class SnackBar {
 
 
     public dismiss(options) {
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
             if (this._snackbar !== null && this._snackbar != "undefined") {
                 try {
                     this._isDismissedManual = true;
                     this._snackbar.dismiss();
 
                     //Return AFTER the item is dismissed, 200ms delay
-                    setTimeout(function () {
+                    setTimeout(() => {
                         resolve({
                             action: "Dismiss",
                             reason: "Manual"


### PR DESCRIPTION
Hi and thanks for this fantastic nativescript plugin,

This pull request concerns the following actions :
- Replace es5 function by es6 to bind this and fix ios bugs.
- Remove module in snackbar.d.ts to add es6 import compatibility

Exemple of bug: 
When a user select the close button of a simpleText snackbar on iOS, the application failed because "this._snackbar" is undefined (l.23 - snackbar.ios.ts).
