### PR TITLE
NSBundle.mainBundle is not a function - #14

### DIFF
--- a/snackbar.ios.ts
+++ b/snackbar.ios.ts
@@ -120,7 +120,7 @@ export class SnackBar {
 
 
     private _getActionText() {
-        let bundle = (parseInt(device.osVersion) >= 10) ? NSBundle.mainBundle : NSBundle.mainBundle()
+        let bundle = (typeof NSBundle.mainBundle === 'function') ? NSBundle.mainBundle() : NSBundle.mainBundle;
         var actionText = bundle.objectForInfoDictionaryKey("NSSnackBarActionText");
         if (actionText != "" && actionText != null) {
             return actionText;


### PR DESCRIPTION
Bug IOS Simultator: NSBundle.mainBundle is not a function - #14