### PR TITLE
Added textColor and backgroundColor on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ public showAction() {
     actionText: this.get('actionText'),
     actionTextColor: '#ff4081',
     snackText: this.get('snackText'),
-    hideDelay: 3500
+    hideDelay: 3500,
+    textColor: '#346db2', // Optional, Android only
+    backgroundColor: '#eaeaea' // Optional, Android only
   };
 
   snackbar.action(options).then((args) => {
@@ -72,6 +74,8 @@ Manually dismiss an active SnackBar
 - **actionTextColor: string**
 - **snackText: string**
 - **hideDelay: number**
+- **textColor: string**
+- **backgroundColor: string**
 
 
 
@@ -80,3 +84,4 @@ Manually dismiss an active SnackBar
 - Steve McNiven-Scott  [@stevemcniven](https://twitter.com/stevemcniven)
 - Nathanael Anderson [@CongoCart](https://twitter.com/congocart)
 - Marc Buils [MarcBuils](http://www.marcbuils.fr/)
+- Davor Peic [@davorpeic](https://twitter.com/davorpeic)

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,4 +25,6 @@ export interface SnackBarOptions {
   actionTextColor: string;
   snackText: string;
   hideDelay: number;
+  textColor?: string;
+  backgroundColor?: string;
 }

--- a/snackbar.android.ts
+++ b/snackbar.android.ts
@@ -69,10 +69,25 @@ export class SnackBar {
         // set the action text, click listener
         this._snackbar.setAction(options.actionText, listener);
 
+        // set action text color
         if (options.actionTextColor) {
           this._snackbar.setActionTextColor(
             new Color(options.actionTextColor).android
           );
+        }
+
+        // set text color
+        if (options.textColor) {
+          let mainTextView = this._snackbar
+            .getView()
+            .findViewById(android.support.design.R.id.snackbar_text);
+          mainTextView.setTextColor(new Color(options.textColor).android);
+        }
+
+        // set background color
+        if (options.backgroundColor) {
+          let sbView = this._snackbar.getView();
+          sbView.setBackgroundColor(new Color(options.backgroundColor).android);
         }
 
         let callback = new this._snackCallback();


### PR DESCRIPTION
Hi,

I added textColor and backgroundColor and updated docs, tested in samsung 4.4.2 and redmi 6.0.1 and working fine. 
- I also made these two optional in `SnackBarOptions` to avoid missing types if not used. 
- Updated docs

In regards of iOS, have you considered maybe updating to official google implementation? https://material.io/components/ios/catalog/snackbars/

ps. should this bump version?

dp