### PR TITLE
view property declarations and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ public showAction() {
     hideDelay: 3500,
     backgroundColor: '#eaeaea', // Optional, Android only
     maxLines: 3, // Optional, Android Only
-    isRTL: false // Optional, Android Only
+    isRTL: false, // Optional, Android Only
+    view: <View>someView // Optional, Android Only, default to topmost().currentPage
   };
 
   snackbar.action(options).then((args) => {
@@ -62,7 +63,7 @@ public showAction() {
 
 Show a simple SnackBar (color args will only work on Android)
 
-- **simple(snackText: string, textColor?: string, backgroundColor?: string, maxLines?: number, isRTL?: boolean): Promise<any>**
+- **simple(snackText: string, textColor?: string, backgroundColor?: string, maxLines?: number, isRTL?: boolean, view?: View): Promise<any>**
 
 Show a SnackBar with Action.
 
@@ -82,3 +83,4 @@ Manually dismiss an active SnackBar
 - **backgroundColor: string**
 - **maxLines: number**
 - **isRTL: boolean**
+- **view: View**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
+import { View } from "ui/core/view";
 /**
  * Represents the SnackBar.
  */
@@ -9,13 +10,15 @@ export declare class SnackBar {
    * @param {string} - The background color of the snackbar. * Android Only *
    * @param {number} - The max lines for the text of the snackbar. * Android Only *
    * @param {boolean} - Set RTL for the textview of the snackbar. * Android Only *
+   * @param {View} - The View to which the snackbar will be attached. Default to topmost().currentPage. * Android Only *
    */
   simple(
     snackText: string,
     textColor?: string,
     backgroundColor?: string,
     maxLines?: number,
-    isRTL?: boolean
+    isRTL?: boolean,
+    view?: View
   ): Promise<any>;
 
   /**
@@ -70,6 +73,13 @@ export interface SnackBarOptions {
    * Use RTL for textview of snackbar.
    */
   isRTL?: boolean;
+
+  /**
+   * *Android Only*
+   * The View to which the snackbar will be attached. Useful with modals.
+   * Default to topmost().currentPage
+   */
+  view?: View;
 }
 
 export enum DismissReasons {


### PR DESCRIPTION
#38 #39 
But does we really need `index.d.ts`? JSDoc don't work in WebStorm for me. Does it works in vscode?
https://github.com/bradmartin/nativescript-snackbar/blob/d9158add161ab0a91e45a30b07fb6d39d67f13cb/src/tsconfig.json#L7

There are also *.map files, which do not contains in the package.
https://github.com/bradmartin/nativescript-snackbar/blob/d9158add161ab0a91e45a30b07fb6d39d67f13cb/src/tsconfig.json#L9
May be we should:
`"declaration": false` -> `"declaration": true`
`"sourceMap": true` -> `"inlineSourceMap": true`